### PR TITLE
chore: drop useless `npm install --only=dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "testEnvironment": "node"
   },
   "scripts": {
-    "ci":
-      "npm install --only=dev && npm run precommit && npm run test && npm run prerelease",
+    "ci": "npm run precommit && npm run test && npm run prerelease",
     "precommit": "lint-staged",
     "pretest": "eslint .",
     "test": "jest",


### PR DESCRIPTION
refs:
- https://docs.npmjs.com/cli/install
- https://stackoverflow.com/questions/36999461/how-to-install-only-devdependencies-using-npm